### PR TITLE
ITL: ssl_cert: vars.ssl_cert_cn: default to "$ssl_cert_altnames$"

### DIFF
--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -579,6 +579,7 @@ object CheckCommand "ssl_cert" {
 
 	vars.ssl_cert_address = "$check_address$"
 	vars.ssl_cert_port = 443
+	vars.ssl_cert_cn = "$ssl_cert_altnames$"
 }
 
 object CheckCommand "varnish" {


### PR DESCRIPTION
This way vars.ssl_cert_altnames keeps working.